### PR TITLE
Call super's -layoutSubviews to make compatible with autolayout.

### DIFF
--- a/AKSegmentedControl/AKSegmentedControl.m
+++ b/AKSegmentedControl/AKSegmentedControl.m
@@ -71,6 +71,8 @@ static CGFloat const kAKButtonSeparatorWidth = 1.0;
 #pragma mark - Layout
 
 - (void)layoutSubviews {
+    [super layoutSubviews];
+
     CGRect contentRect = UIEdgeInsetsInsetRect(self.bounds, _contentEdgeInsets);
     
     NSUInteger buttonsCount    = _buttonsArray.count;


### PR DESCRIPTION
This fixes the following error when using autolayout:

*** Terminating app due to uncaught exception '
NSInternalInconsistencyException', reason: 'Auto Layout still required
after executing -layoutSubviews. AKSegmentedControl's implementation of
-layoutSubviews needs to call super.'